### PR TITLE
don't store data as state in DataMixin

### DIFF
--- a/src/DataMixin.js
+++ b/src/DataMixin.js
@@ -12,10 +12,10 @@ module.exports = {
 
   getInitialState() {
     return {
-      // Clone the initialData.
-      data: this.props.initialData.slice(0),
       sortBy: this.props.initialSortBy,
-      filterValues: {},
+      filterValues: {
+        globalSearch: ""
+      },
       currentPage: 0,
       pageLength: this.props.initialPageLength
     };
@@ -33,31 +33,17 @@ module.exports = {
     };
   },
 
-  componentWillMount() {
-    // Do the initial sorting if specified.
-    var {sortBy, data} = this.state;
-    if (sortBy) {
-      this.setState({ data: sort(sortBy, data) });
-    }
-  },
-
   onSort(sortBy) {
     this.setState({
-      sortBy: sortBy,
-      data: sort(sortBy, this.state.data)
+      sortBy: sortBy
     });
   },
 
   onFilter(filterName, filterValue) {
-    var {filterValues, sortBy} = this.state;
-    var {initialData, filters} = this.props;
-
+    var {filterValues} = this.state;
     filterValues[filterName] = filterValue;
-    var newData = filter(filters, filterValues, initialData);
-    newData = sort(sortBy, newData);
 
     this.setState({
-      data: newData,
       filterValues: filterValues,
       currentPage: 0
     });
@@ -65,13 +51,18 @@ module.exports = {
 
   // Pagination
   buildPage() {
-    var {data, currentPage, pageLength} = this.state;
+    var {filterValues, sortBy, currentPage, pageLength} = this.state;
+    var {filters} = this.props;
     var start = pageLength * currentPage;
 
+    var pageData = filter(filters, filterValues, this.props.initialData);
+    pageData = sort(sortBy, pageData);
+    pageData = pageData.slice(start, start + pageLength);
+
     return {
-      data: data.slice(start, start + pageLength),
+      data: pageData,
       currentPage: currentPage,
-      totalPages: Math.ceil(data.length / pageLength)
+      totalPages: Math.ceil(pageData.length / pageLength)
     };
   },
 

--- a/src/DataMixin.js
+++ b/src/DataMixin.js
@@ -57,10 +57,9 @@ module.exports = {
 
     var pageData = filter(filters, filterValues, this.props.initialData);
     pageData = sort(sortBy, pageData);
-    pageData = pageData.slice(start, start + pageLength);
 
     return {
-      data: pageData,
+      data: pageData.slice(start, start + pageLength),
       currentPage: currentPage,
       totalPages: Math.ceil(pageData.length / pageLength)
     };


### PR DESCRIPTION
In our app, we render DataTable immediately with no data, and then render it again when our data is loaded. Our data also continues to occasionally update in the background. DataTable does not currently update with the new data.

I spent some time looking at the code and this is happening because the initialData that is passed in is copied to data and stored as state. Since state persists across renders, it does not update (unless you happen to filter, which copies from initialData again, which does properly get updated).

I've forked and made a fix that is working for us, as this issue makes react-data-components unworkable for us, but we really like it otherwise.

My fix is essentially to not store data as state at all, and do all the sorting, filtering and pagination at the time buildPage is called. Although it is working for us, our app is currently new and small so I don't know whether this would have unexpected performance implications or other issues.

I was unable to get tests running -- from a commit back in March, it sounds like that might be a known issue.

If it makes sense to you, we would love to get this merged (or for the issue to be fixed another way) so that we can use your repo for future changes, etc.