### PR TITLE
Altered the sorting functionality so that it handles null values.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,12 @@ function some(pred, obj) {
  */
 var sortByFunc =
     (prop) =>
-        (a, b) => a[prop] < b[prop] ? -1 : a[prop] > b[prop] ? 1 : 0;
+        (a, b) => {
+          if (b[prop] === null && a[prop] === null) { return 0 }
+          if (a[prop] === null) { return -1 }
+          if (b[prop] === null) { return 1 }
+          return a[prop] < b[prop] ? -1 : a[prop] > b[prop] ? 1 : 0;
+        }
 
 /**
  * @param {object} sortBy Object containing `prop` and `order`.


### PR DESCRIPTION
We were having an issue where when 1 or more values were null, sorting the data would become unpredictable because comparison against null always resulted in returning 0. So I made this change to correct that.

The tests were failing before making the changes, but I saw in the commit history that it is known. So for now I did not update any tests.

P.S. I work with @taralbass who had opened a previous pull request, in case you were wondering about the recent PRs.