### PR TITLE
Modify DataTable to pass down buildRowOptions to Table

### DIFF
--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -47,6 +47,7 @@ var DataTable = React.createClass({
           dataArray={page.data}
           columns={this.props.columns}
           keys={this.props.keys}
+          buildRowOptions={this.props.buildRowOptions}
           sortBy={this.state.sortBy}
           onSort={this.onSort}
         />


### PR DESCRIPTION
This PR enables the use of buildRowOptions on DataTables.