### PR TITLE
Make search, dropdown and pagination optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ var data = [
 
 ReactDOM.render((
     <DataTable
+      dropdown
+      pagination
+      search
+      className="container"
       keys="name"
       columns={columns}
       initialData={data}
@@ -52,4 +56,3 @@ ReactDOM.render((
 ```
 
 See [complete example](example/table/main.js).
-

--- a/example/table/main.js
+++ b/example/table/main.js
@@ -19,6 +19,9 @@ function buildTable(data) {
 
   return (
     <DataTable
+      dropdown={true}
+      pagination={true}
+      search={true}
       className="container"
       keys="id"
       columns={tableColumns}

--- a/example/table/main.js
+++ b/example/table/main.js
@@ -19,9 +19,9 @@ function buildTable(data) {
 
   return (
     <DataTable
-      dropdown={true}
-      pagination={true}
-      search={true}
+      dropdown
+      pagination
+      search
       className="container"
       keys="id"
       columns={tableColumns}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-data-components",
+  "name": "@viaforensics/react-data-components",
   "version": "1.1.0",
   "description": "React data components",
   "keywords": [
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/carlosrocha/react-data-components"
+    "url": "git+https://github.com/viaforensics/react-data-components.git"
   },
   "dependencies": {
     "lodash": "^4.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viaforensics/react-data-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React data components",
   "keywords": [
     "pagination",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viaforensics/react-data-components",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React data components",
   "keywords": [
     "pagination",

--- a/src/PartialTable.js
+++ b/src/PartialTable.js
@@ -6,7 +6,7 @@ export default class PartialTable extends Component {
 
   render() {
     const {
-      onFilter, onPageSizeChange, onPageNumberChange, onSort,
+      className, onFilter, onPageSizeChange, onPageNumberChange, onSort,
       pageLengthOptions, columns, keys, buildRowOptions,
     } = this.props;
 
@@ -16,7 +16,7 @@ export default class PartialTable extends Component {
     } = this.props.data;
 
     return (
-      <div className="container">
+      <div className={className}>
         <div className="row">
           <div className="col-xs-4">
             <div>

--- a/src/PartialTable.js
+++ b/src/PartialTable.js
@@ -6,7 +6,7 @@ export default class PartialTable extends Component {
 
   render() {
     const {
-      search, dropdown, pagination, className,
+      search, dropdown, pagination, className, onClick,
       onFilter, onPageSizeChange, onPageNumberChange, onSort,
       pageLengthOptions, columns, keys, buildRowOptions,
     } = this.props;
@@ -54,6 +54,7 @@ export default class PartialTable extends Component {
           </div> : null}
         </div>
         <Table
+          onClick={onClick}
           className="table table-bordered"
           dataArray={page}
           columns={columns}

--- a/src/PartialTable.js
+++ b/src/PartialTable.js
@@ -6,7 +6,8 @@ export default class PartialTable extends Component {
 
   render() {
     const {
-      search, dropdown, pagination, className, onFilter, onPageSizeChange, onPageNumberChange, onSort,
+      search, dropdown, pagination, className,
+      onFilter, onPageSizeChange, onPageNumberChange, onSort,
       pageLengthOptions, columns, keys, buildRowOptions,
     } = this.props;
 

--- a/src/PartialTable.js
+++ b/src/PartialTable.js
@@ -17,7 +17,7 @@ export default class PartialTable extends Component {
     } = this.props.data;
 
     return (
-      <div className={className}>
+      <div className={className || 'container'}>
         <div className="row">
           <div className="col-xs-4">
             {dropdown ? <div>

--- a/src/PartialTable.js
+++ b/src/PartialTable.js
@@ -6,7 +6,7 @@ export default class PartialTable extends Component {
 
   render() {
     const {
-      className, onFilter, onPageSizeChange, onPageNumberChange, onSort,
+      search, dropdown, pagination, className, onFilter, onPageSizeChange, onPageNumberChange, onSort,
       pageLengthOptions, columns, keys, buildRowOptions,
     } = this.props;
 
@@ -19,7 +19,7 @@ export default class PartialTable extends Component {
       <div className={className}>
         <div className="row">
           <div className="col-xs-4">
-            <div>
+            {dropdown ? <div>
               <label htmlFor="page-menu">Page size:</label>
               <select
                 id="page-menu"
@@ -32,8 +32,8 @@ export default class PartialTable extends Component {
                   </option>
                 )}
               </select>
-            </div>
-            <div>
+            </div> : null}
+            {search ? <div>
               <label htmlFor="search-field">Search:</label>
               <input
                 id="search-field"
@@ -41,16 +41,16 @@ export default class PartialTable extends Component {
                 value={filterValues.globalSearch}
                 onChange={onFilter.bind(null, 'globalSearch')}
               />
-            </div>
+            </div> : null}
           </div>
-          <div className="col-xs-8">
+          {pagination ? <div className="col-xs-8">
             <Pagination
               className="pagination pull-right"
               currentPage={pageNumber}
               totalPages={totalPages}
               onChangePage={onPageNumberChange}
             />
-          </div>
+          </div> : null}
         </div>
         <Table
           className="table table-bordered"

--- a/src/Table.js
+++ b/src/Table.js
@@ -130,6 +130,11 @@ export default class Table extends Component {
         <tr onClick={onClick} data-index={getKeys(row)} key={getKeys(row)} {...trProps}>
           {columns.map((col, i) => {
             let val = getCellValue(col, row)
+            // truncate long strings
+            const trimAt = 40
+            if (columns.length > 1 && val.length > trimAt && val.indexOf('\n') === -1) {
+              val = val.substring(0, trimAt) + '...'
+            }
             switch (typeof val) {
               case 'boolean':
                 val = String(val)

--- a/src/Table.js
+++ b/src/Table.js
@@ -128,11 +128,18 @@ export default class Table extends Component {
 
       return (
         <tr onClick={onClick} data-index={getKeys(row)} key={getKeys(row)} {...trProps}>
-          {columns.map((col, i) =>
-            <td key={i} className={getCellClass(col, row)}>
-              {getCellValue(col, row)}
+          {columns.map((col, i) => {
+            let val = getCellValue(col, row)
+            switch (typeof val) {
+              case 'boolean':
+                val = String(val)
+              case 'object':
+                val = JSON.stringify(val, null, ' ')
+            }
+            return <td key={i} className={getCellClass(col, row)}>
+              {val}
             </td>
-          )}
+          })}
         </tr>
       );
     });

--- a/src/Table.js
+++ b/src/Table.js
@@ -96,7 +96,7 @@ export default class Table extends Component {
   render() {
     const {
       columns, keys, buildRowOptions, sortBy,
-      onSort, dataArray, ...otherProps,
+      onClick, onSort, dataArray, ...otherProps,
     } = this.props;
 
     const headers = columns.map((col, idx) => {
@@ -127,7 +127,7 @@ export default class Table extends Component {
       const trProps = buildRowOptions ? buildRowOptions(row) : {};
 
       return (
-        <tr key={getKeys(row)} {...trProps}>
+        <tr onClick={onClick} data-index={getKeys(row)} key={getKeys(row)} {...trProps}>
           {columns.map((col, i) =>
             <td key={i} className={getCellClass(col, row)}>
               {getCellValue(col, row)}

--- a/src/Table.js
+++ b/src/Table.js
@@ -132,7 +132,7 @@ export default class Table extends Component {
             let val = getCellValue(col, row)
             // truncate long strings
             const trimAt = 40
-            if (columns.length > 1 && val.length > trimAt && val.indexOf('\n') === -1) {
+            if (columns.length > 1 && val && val.length > trimAt && val.indexOf('\n') === -1) {
               val = val.substring(0, trimAt) + '...'
             }
             switch (typeof val) {


### PR DESCRIPTION
This change adds a few additional `props` to hide/show the search, dropdown and pagination in cases where you might not want those features

Also allows for a custom `className` in case the additional padding from `container` isn't wanted.